### PR TITLE
mycroft.not.paired

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -90,6 +90,10 @@ class PairingSkill(OVOSSkill):
         self.gui.register_handler("mycroft.device.confirm.tts", self.select_tts)
         self.nato_dict = self.translate_namedvalues('codes')
 
+        # trigger initial pairing
+        if not is_paired():
+            self.bus.emit(Message("mycroft.not.paired"))
+
     def show_loading_screen(self, message=None):
         self.handle_display_manager("LoadingScreen")
 


### PR DESCRIPTION
there is some race condition and skill sometimes misses the bus message

DevicePrimer will be deprecated in ovos-core


companion PR https://github.com/OpenVoiceOS/ovos-core/pull/87